### PR TITLE
Fix %q Verb - Missing String Escape in Sprintf

### DIFF
--- a/fmt_template.go
+++ b/fmt_template.go
@@ -374,10 +374,24 @@ func (c *Conv) formatValue(arg any, formatChar rune, param int, formatSpec strin
 		// Quoted string or rune
 		switch v := arg.(type) {
 		case string:
-			return "\"" + v + "\""
+			return Convert(v).Quote().String()
 		case rune:
+			if v == '\'' {
+				return "'\\''"
+			}
+			s := Convert(string(v)).Quote().String()
+			if len(s) >= 2 {
+				return "'" + s[1:len(s)-1] + "'"
+			}
 			return "'" + string(v) + "'"
 		case byte:
+			if v == '\'' {
+				return "'\\''"
+			}
+			s := Convert(string(rune(v))).Quote().String()
+			if len(s) >= 2 {
+				return "'" + s[1:len(s)-1] + "'"
+			}
 			return "'" + string(rune(v)) + "'"
 		}
 		c.wrInvalidTypeErr(formatSpec)


### PR DESCRIPTION
This change fixes a bug in `tinywasm/fmt` where the `%q` verb (quoted string) did not properly escape special characters, causing issues when formatting JSON or other strings with internal quotes.

The fix reuses the existing `Conv.Quote()` logic for strings. Additionally, it improves the formatting of runes and bytes under `%q` to ensure they are properly escaped and wrapped in single quotes, including special handling for the single-quote character itself.

Tests were verified using the existing reproduction test `fmt_q_escape_test.go` and new manual checks for runes and bytes.

---
*PR created automatically by Jules for task [2219196727484868964](https://jules.google.com/task/2219196727484868964) started by @cdvelop*